### PR TITLE
Use `scico` to display the color scale of estimated eigenfunctions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SpatPCA
 Title: Regularized Principal Component Analysis for Spatial Data
-Version: 1.3.0.2
+Version: 1.3.0.3
 Authors@R: c(person(
                 given = "Wen-Ting",
                 family = "Wang",
@@ -33,7 +33,7 @@ Suggests:
     gifski,
     tidyr,
     fields,
-    dichromat
+    scico
 SystemRequirements: C++11, GNU make
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/man/SpatPCA-package.Rd
+++ b/man/SpatPCA-package.Rd
@@ -8,8 +8,8 @@ A new regularization approach to estimate the leading spatial patterns via smoot
 \details{\tabular{ll}{
 Package:\tab SpatPCA\cr
 Type:\tab  Package\cr
-Version:\tab   1.3.0.2\cr
-Date:\tab   2021-01-02\cr
+Version:\tab   1.3.0.3\cr
+Date:\tab   2021-01-03\cr
 License: \tab GPL version 3\cr
 }
 }

--- a/vignettes/demo-two-dim-location.Rmd
+++ b/vignettes/demo-two-dim-location.Rmd
@@ -3,8 +3,8 @@ title: "Capture the Dominant Spatial Patten with Two-Dimensional Locations"
 author: "Wen-Ting Wang"
 output:
     rmarkdown::html_vignette:
-    fig_width: 7
-    fig_height: 7
+    fig_width: 6
+    fig_height: 4
 vignette: >
   %\VignetteIndexEntry{Capture the Dominant Spatial Patten with Two-Dimensional Locations}
   %\VignetteEngine{knitr::rmarkdown}
@@ -32,25 +32,17 @@ library(dplyr)
 library(tidyr)
 library(gifski)
 library(fields)
-library(dichromat)
+library(scico)
 
-base_theme <- theme_minimal(base_size = 12, base_family = "Times") +
+base_theme <- theme_minimal(base_size = 10, base_family = "Times") +
   theme(legend.position = "bottom")
-bluescale <- colorRampPalette(c(
-  "#FFFFCC",
-  "#C7E9B4",
-  "#7FCDBB",
-  "#40B6C4",
-  "#2C7FB8" ,
-  "#253494"
-))
 fill_bar <- guides(fill = guide_colourbar(
     barwidth = 10,
     barheight = 0.5,
     label.position = "bottom")
   )
-coltab <- bluescale(1024)
-color_scale_limit <- c(-.27, .27)
+coltab <- scico(128, palette = 'vik')
+color_scale_limit <- c(-.28, .28)
 ```
 #### True spatial pattern (eigenfunction)
 - The underlying spatial pattern below indicates realizations will vary dramatically at the center and almost unchange at the both ends of the curve.


### PR DESCRIPTION
### Why change
- Reinforce the effect of `spatpca` visually

### Change
- Use the symmetric color scale by `scico`

### Screenshot
- Before
<img width="880" alt="image" src="https://user-images.githubusercontent.com/7146349/103480260-39227400-4e0e-11eb-857a-f587760f38cc.png">

- After
<img width="527" alt="image" src="https://user-images.githubusercontent.com/7146349/103480241-1db76900-4e0e-11eb-858c-e5554fb822c0.png">
